### PR TITLE
Added a more robust way to check for path traversal

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -434,7 +434,7 @@ func checkForPathTraversal(path string, client_addr string) bool {
 
 // redirectRoot redirects server root to /view?dir=/.
 func redirectRoot(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/view?dir=/", http.StatusFound)
+	http.Redirect(w, r, "/view?dir=./", http.StatusFound)
 }
 
 // getFile serves a single file requested via URL
@@ -600,7 +600,7 @@ func viewDir(w http.ResponseWriter, r *http.Request) {
 	// What is the parent for current folder?
 	parent := filepath.Dir(dir)
 	if parent == "." {
-		parent = "/"
+		parent = "./"
 	}
 
 	if checkForPathTraversal(dir, r.RemoteAddr) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -389,6 +389,7 @@ func checkAuth(w http.ResponseWriter, r *http.Request) bool {
 	if AUTH {
 		user, pass, ok := r.BasicAuth()
 		if !ok || (user != USER || !checkPass(pass, PASS)) {
+			time.Sleep(1 * time.Second) // slow down brute force attacks
 			return false
 		}
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,11 +10,9 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/sha512"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/base64"
 	"encoding/pem"
 	"errors"
 	"flag"
@@ -822,8 +820,6 @@ func writeCertFile(name string, data []byte) error {
 /*
 getPass - Get password interactively from stdin,
 keep retrying until input matches.
-NOTE: We could probably come up with a better way to hash passwords,
-but IDK if it really matters.
 */
 func getPass() string {
 	reader := bufio.NewReader(os.Stdin)
@@ -837,17 +833,11 @@ func getPass() string {
 		fmt.Print("Enter password again: ")
 		p2, _ = reader.ReadString('\n')
 	}
-
-	sha512 := sha512.New()
-	sha512.Write([]byte(strings.TrimSpace(p1)))
-
-	return base64.StdEncoding.EncodeToString(sha512.Sum(nil))
+	
+	return strings.TrimSpace(p1)
 }
 
 // checkPass checks the input password against the one setup on cmd line.
-func checkPass(input, password string) bool {
-	sha := sha512.New()
-	sha.Write([]byte(input))
-	inpass := base64.StdEncoding.EncodeToString(sha.Sum(nil))
+func checkPass(inpass string, password string) bool {
 	return inpass == password
 }


### PR DESCRIPTION
Hello, first of all, thank you for writing this small go fileserver. This was exactly what I was looking for.
I've made two small bugfixes:

1. Improved path traversal check.
Checking for '..' in the input did work, but it also prevented the user from going into a folder that was named, for example, 'my..folder'. That's why I've implemented a check for the base directory instead. Let's say you've started the webserver with the directory '/home/user', then the new path traversal check will check if the path the user wants to access starts with '/home/user', so that '/home/user/my..folder' can be accessed, but '/home/user/..' can not, because it would equate to an absolute path of '/home', which does not start with '/home/user' and therefore will be denied.

2. Fixed a bug that appeared for me in firefox
After denying a path traversal, go-fileserver redirected to '/view?dir=/', which caused Firefox to display this error message:
"_The page isn’t redirecting properly
Firefox has detected that the server is redirecting the request for this address in a way that will never complete._"
When I changed the redirect to '/view?dir=./', everything was fine.