### PR TITLE
New path traversal check

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -434,7 +434,7 @@ func checkForPathTraversal(path string, client_addr string) bool {
 
 // redirectRoot redirects server root to /view?dir=/.
 func redirectRoot(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/view?dir=/", http.StatusFound)
+	http.Redirect(w, r, "/view?dir=./", http.StatusFound)
 }
 
 // getFile serves a single file requested via URL
@@ -600,7 +600,7 @@ func viewDir(w http.ResponseWriter, r *http.Request) {
 	// What is the parent for current folder?
 	parent := filepath.Dir(dir)
 	if parent == "." {
-		parent = "/"
+		parent = "./"
 	}
 
 	if checkForPathTraversal(dir, r.RemoteAddr) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -434,7 +434,7 @@ func checkForPathTraversal(path string, client_addr string) bool {
 
 // redirectRoot redirects server root to /view?dir=/.
 func redirectRoot(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/view?dir=./", http.StatusFound)
+	http.Redirect(w, r, "/view?dir=/", http.StatusFound)
 }
 
 // getFile serves a single file requested via URL
@@ -601,7 +601,7 @@ func viewDir(w http.ResponseWriter, r *http.Request) {
 	// What is the parent for current folder?
 	parent := filepath.Dir(dir)
 	if parent == "." {
-		parent = "./"
+		parent = "/"
 	}
 
 	// create real path from the server's root folder and navigated folder


### PR DESCRIPTION
Hello, thanks for your patience. This pull request includes the new path traversal check, but not the bugfix for firefox that does not seem to be necessary anymore, so I reverted it.

Improved path traversal check.
Checking for '..' in the input did work, but it also prevented the user from going into a folder that was named, for example, 'my..folder'. That's why I've implemented a check for the base directory instead. Let's say you've started the webserver with the directory '/home/user', then the new path traversal check will check if the path the user wants to access starts with '/home/user', so that '/home/user/my..folder' can be accessed, but '/home/user/..' can not, because it would equate to an absolute path of '/home', which does not start with '/home/user' and therefore will be denied.