### PR TITLE
Improvement to basic auth

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -389,6 +389,7 @@ func checkAuth(w http.ResponseWriter, r *http.Request) bool {
 	if AUTH {
 		user, pass, ok := r.BasicAuth()
 		if !ok || (user != USER || !checkPass(pass, PASS)) {
+			time.Sleep(1 * time.Second) // slow down brute force attacks
 			return false
 		}
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,11 +10,9 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/sha512"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/base64"
 	"encoding/pem"
 	"errors"
 	"flag"
@@ -822,8 +820,6 @@ func writeCertFile(name string, data []byte) error {
 /*
 getPass - Get password interactively from stdin,
 keep retrying until input matches.
-NOTE: We could probably come up with a better way to hash passwords,
-but IDK if it really matters.
 */
 func getPass() string {
 	reader := bufio.NewReader(os.Stdin)
@@ -837,17 +833,11 @@ func getPass() string {
 		fmt.Print("Enter password again: ")
 		p2, _ = reader.ReadString('\n')
 	}
-
-	sha512 := sha512.New()
-	sha512.Write([]byte(strings.TrimSpace(p1)))
-
-	return base64.StdEncoding.EncodeToString(sha512.Sum(nil))
+	
+	return strings.TrimSpace(p1)
 }
 
 // checkPass checks the input password against the one setup on cmd line.
-func checkPass(input, password string) bool {
-	sha := sha512.New()
-	sha.Write([]byte(input))
-	inpass := base64.StdEncoding.EncodeToString(sha.Sum(nil))
+func checkPass(inpass string, password string) bool {
 	return inpass == password
 }


### PR DESCRIPTION
I did two things here:

1. Added a sleep of 1 second after a failed login attempt via basic auth. This is to slow down brute force attacks, which basic auth otherwise is very vulnerable to. This cooldown is for every connection, so an attacker could open many connections and start brute forcing. However, this still should provide enough security for a good password. To protect a weak password from brute forcing, we probably would need to implement rate limiting for every ipv4 address and every /64 ipv6 subnet, which would have it's own drawbacks. I think the warning in the README to pick a good password together with this 1 second sleep should be good.

2. Removed the sha512 hashing of the password that is given via the command line for http basic auth. I see two attack paths on the password:
The first is a brute force attack over the network. In this case, the sha512 hashing would slow down such an attack a little, but at the cost of increased load of the server's cpu. A sleep after an authentication attempt does the same with a predictable time penalty, but without increasing cpu load.
The second would be if an attacker would get hold of the password hash somehow. In this case, I think one round of sha512 by itself would not offer state of the art protection and if this attack vector was probable, something like argon2id should be used instead. However, since the password is kept in ram anyway and is never saved to disk, I don't think the hashing is necessary at all, since many passwords and keys are kept in ram, like disk encryption keys or ssh keys after they're unlocked or gpg keys after unlocking and this is generally considered secure.