### PR TITLE
Changed uploadFiles() to also be able to handle big files

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -675,21 +675,30 @@ func uploadFiles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := r.ParseMultipartForm(32 << 20); err != nil {
+	reader, err := r.MultipartReader()
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
-
-	// prevents a panic if empty
-	if r.MultipartForm == nil {
 		return
 	}
 
-	files := r.MultipartForm.File["file-upload"]
-
 	dir := filepath.Clean(r.FormValue("directory"))
 
-	for i := range files {
-		path := filepath.Clean(filepath.Join(FILE_PATH, dir, files[i].Filename))
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		if part.FormName() != "file-upload" {
+			continue
+		}
+
+		filename := filepath.Base(part.FileName())
+		path := filepath.Clean(filepath.Join(FILE_PATH, dir, filename))
 
 		if checkForPathTraversal(path, r.RemoteAddr) {
 			// prevent path traversal, redirect to home page
@@ -697,7 +706,7 @@ func uploadFiles(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		file, err := files[i].Open()
+		file, err := os.Create(path)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -705,13 +714,12 @@ func uploadFiles(w http.ResponseWriter, r *http.Request) {
 
 		defer file.Close()
 
-		if err = copyUploadFile(path, file); err != nil {
+		if _, err = io.Copy(file, part); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
 		maybeLog("CLIENT: %s UPLOAD: %s\n", r.RemoteAddr, path)
-
 	}
 
 	// reload the current page on successful upload

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -324,24 +324,6 @@ func maybeLog(msg string, args ...any) {
 	}
 }
 
-/*
-copyUploadFile copies a multipart form file to the file system
-returns an error so we can return a 500 instead of crashing/exiting
-*/
-func copyUploadFile(path string, src multipart.File) error {
-	dst, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-
-	defer dst.Close()
-	_, err = io.Copy(dst, src)
-	if err != nil {
-		return err
-	}
-	return err
-}
-
 // sizeToStr converts a file size in bytes to a human friendy string.
 func sizeToStr(n int64) string {
 	if n == 0 {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,7 +25,6 @@ import (
 	"log"
 	"math"
 	"math/big"
-	"mime/multipart"
 	"net"
 	"net/http"
 	"os"


### PR DESCRIPTION
I've noticed that the fileserver would crash after filling up /tmp and ram when uploading a big file. So I rewrote the uploadFiles function to basically write the uploaded file directly to the destination, instead of caching it whole and then copying it.
I've tested this change with uploading a 100GB file and then comparing the sha256 sums, which was identical. I also tested uploading multiple files and comparing the sha256 sums, which also worked.